### PR TITLE
Fixing main class for renamed Apache Mesos packaging

### DIFF
--- a/debian/chronos.bash
+++ b/debian/chronos.bash
@@ -60,7 +60,7 @@ JAVA_OPTS="$JAVA_OPTS -Djava.library.path=${JAVA_LIBPATH:-/usr/lib/} -cp $chrono
 ##-============================================================================
 
 echo -e "Launch Chronos"
-CMD="java $JAVA_OPTS com.airbnb.scheduler.Main $EXTRA_OPTS $@" 
+CMD="java $JAVA_OPTS org.apache.mesos.chronos.scheduler.Main $EXTRA_OPTS $@" 
 echo -e "cmd: $CMD"
 exec $CMD
 


### PR DESCRIPTION
The main class for Chronos has been moved in https://github.com/mesos/chronos/commit/36a294d4714e545de91fcda920429faff15a1746

This change fixes the deb package to call the correct main class.